### PR TITLE
Fixing a bug where a posts fails to be inserted into the DB if the ex…

### DIFF
--- a/syndicatedpost.class.php
+++ b/syndicatedpost.class.php
@@ -131,7 +131,8 @@ class SyndicatedPost {
 			$excerpt = apply_filters('syndicated_item_excerpt', $this->excerpt(), $this);
 
 			if (!empty($excerpt)):
-				$this->post['post_excerpt'] = $excerpt;
+                // Wordpress post_excerpt needs to be less than 65534 characters
+                $this->post['post_excerpt'] = substr($excerpt, 0, 65534);
 			endif;
 
 			// Dealing with timestamps in WordPress is so fucking fucked.


### PR DESCRIPTION
…cerpt is more than 65534 characters.

This can happen when there is no summary and the text is copied over from content.